### PR TITLE
fix: og:locale meta tag

### DIFF
--- a/components/layout/LayoutHead.tsx
+++ b/components/layout/LayoutHead.tsx
@@ -68,7 +68,7 @@ const LayoutHead: React.FC<LayoutHeadProps> = (props) => {
       <meta content={imageSizes[0].toString()} property="og:image:width" />
       <meta content={imageSizes[1].toString()} property="og:image:height" />
       <meta content={title} property="og:image:alt" />
-      <meta content="en" property="og:locale" />
+      <meta content="es" property="og:locale" />
       <meta content="website" property="og:type" />
       <meta content="Adopcanem" property="og:site_name" />
       <meta content={description} property="og:description" />


### PR DESCRIPTION
**Description**

Replaces `og:locale` meta tag from `en` to `es` in 