### PR TITLE
Fix: updates in History, Family and Transit sections

### DIFF
--- a/components/section/Section.tsx
+++ b/components/section/Section.tsx
@@ -17,6 +17,8 @@ interface SectionProps {
   dividerColor?: string;
   /** Wether to add or not a suttle background gradient effect. */
   hasGradientEffect?: boolean;
+  /** Wether section has default padding or not. */
+  hasPadding?: boolean;
 }
 
 const Section: React.FC<SectionProps> = (props) => {
@@ -27,6 +29,7 @@ const Section: React.FC<SectionProps> = (props) => {
     backgroundIsImage = false,
     backgroundImage = "https://www.petassure.com/petassure/file-streams/page/DKhmRtazcw1FPjHr00Myg4caring-for-pets-teaches-children-responsibility.jpg.jpg",
     hasGradientEffect = false,
+    hasPadding = true,
     children,
   } = props;
 
@@ -43,7 +46,7 @@ const Section: React.FC<SectionProps> = (props) => {
         <Box
           bgGradient={hasGradientEffect ? "linear(to-r, blackAlpha.600, transparent)" : "none"}
           paddingX={{base: 4, md: 8}}
-          paddingY={[20, 30, 40, 60, 150]}
+          paddingY={hasPadding ? [20, 30, 40, 60, 150] : 0}
         >
           <Container maxWidth="container.xl">
             {children}

--- a/components/section/Section.tsx
+++ b/components/section/Section.tsx
@@ -48,7 +48,7 @@ const Section: React.FC<SectionProps> = (props) => {
           paddingX={{base: 4, md: 8}}
           paddingY={hasPadding ? [20, 30, 40, 60, 150] : 0}
         >
-          <Container maxWidth="container.xl">
+          <Container maxWidth={hasPadding ? "container.xl" : "auto"}>
             {children}
             {hasDivider && <SectionDivider backgroundColor={dividerColor} />}
           </Container>

--- a/screens/Home/sections/Family.tsx
+++ b/screens/Home/sections/Family.tsx
@@ -4,8 +4,8 @@ import React from "react";
 import Section from "components/section/Section";
 
 const FamilySection: React.FC = () => {
-  const display = useBreakpointValue({base: "none", md: "block"});
-  const colspan = useBreakpointValue({base: 1, md: 2});
+  const display = useBreakpointValue({base: "none"});
+  const colspan = useBreakpointValue({base: 1});
 
   return (
     <Section backgroundColor="white" dividerColor="#E5E5E5" hasPadding={false}>
@@ -14,7 +14,7 @@ const FamilySection: React.FC = () => {
         overflow="hidden"
         pb={[5, 60]}
         position="relative"
-        templateColumns={{base: "0 repeat(4, 1fr) 0", md: "repeat(6, 1fr)"}}
+        templateColumns={{base: "0 repeat(4, 1fr) 0"}}
         templateRows="repeat(3, 1fr)"
       >
         <GridItem
@@ -48,7 +48,7 @@ const FamilySection: React.FC = () => {
             display="flex"
             h="100%"
             justifyContent="center"
-            minHeight={80}
+            minHeight={{base: "lg", md: "xl"}}
             padding={[2, 5, 10]}
           >
             <Text align="center" color="white" fontSize={["2xl", null, "4xl"]} fontWeight={700}>
@@ -78,7 +78,6 @@ const FamilySection: React.FC = () => {
           borderRadius="2xl"
           colEnd={3}
           colSpan={colspan}
-          // display={ display }
         />
         <GridItem
           backgroundImage="url(https://www.hola.com/imagenes/mascotas/20211014197674/educar-ninos-perros-convivencia-sin-problema-dn/1-6-902/como-educar-perros-ninos-convivencia-sin-problemas-t.jpg)"

--- a/screens/Home/sections/Family.tsx
+++ b/screens/Home/sections/Family.tsx
@@ -8,12 +8,12 @@ const FamilySection: React.FC = () => {
   const colspan = useBreakpointValue({base: 1, md: 2});
 
   return (
-    <Section backgroundColor="white" dividerColor="#E5E5E5">
+    <Section backgroundColor="white" dividerColor="#E5E5E5" hasPadding={false}>
       <Grid
         gap={3}
         overflow="hidden"
+        pb={[5, 60]}
         position="relative"
-        py={[5, 10]}
         templateColumns={{base: "0 repeat(4, 1fr) 0", md: "repeat(6, 1fr)"}}
         templateRows="repeat(3, 1fr)"
       >

--- a/screens/Home/sections/History.tsx
+++ b/screens/Home/sections/History.tsx
@@ -31,6 +31,26 @@ const History: React.FC = () => {
             comprar alimento.
           </Text>
         </VStack>
+        <Box
+          backgroundColor="rgba(253, 177, 69, 0.4)"
+          borderRadius="50%"
+          filter="blur(5px)"
+          height="50px"
+          left={"150px"}
+          position="absolute"
+          top={"40px"}
+          width="50px"
+        />
+        <Box
+          backgroundColor="rgba(253, 177, 69, 0.4)"
+          borderRadius="50%"
+          filter="blur(8px)"
+          height="300px"
+          left={"-150px"}
+          position="absolute"
+          top={"40px"}
+          width="300px"
+        />
         <Box position="absolute" right={"-200px"} top={"-400px"}>
           <Paws />
         </Box>
@@ -122,6 +142,26 @@ const History: React.FC = () => {
             </VStack>
           </GridItem>
         </Grid>
+        <Box
+          backgroundColor="rgba(253, 177, 69, 0.4)"
+          borderRadius="50%"
+          bottom={"380px"}
+          filter="blur(5px)"
+          height="50px"
+          position="absolute"
+          right={"100px"}
+          width="50px"
+        />
+        <Box
+          backgroundColor="rgba(253, 177, 69, 0.4)"
+          borderRadius="50%"
+          bottom={"50px"}
+          filter="blur(8px)"
+          height="300px"
+          position="absolute"
+          right={"-150px"}
+          width="300px"
+        />
         <Box bottom={"-200px"} left={0} position="absolute">
           <Paws />
         </Box>

--- a/screens/Home/sections/Transit.tsx
+++ b/screens/Home/sections/Transit.tsx
@@ -8,7 +8,7 @@ const Transit: React.FC = () => {
       backgroundIsImage
       backgroundColor="gray.200"
       backgroundImage="https://images.unsplash.com/photo-1548199973-03cce0bbc87b?ixlib=rb-1.2.1&raw_url=true&q=80&fm=jpg&crop=entropy&cs=tinysrgb&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1469"
-      dividerColor="white"
+      hasDivider={false}
     >
       <Stack
         alignItems="center"


### PR DESCRIPTION
In History section: to make the paws appear to end below adjoining sections, I make two changes.
1. update padding in Family section 
2. remove divider from Transit section

Also, I add background circles in History section.